### PR TITLE
ci: Update CI, 3.8 EOL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone Repository


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Remove Python 3.8 from CI **before** EOL.
