### PR TITLE
fix: Cleanout old code

### DIFF
--- a/supabase_functions/__init__.py
+++ b/supabase_functions/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Literal, Union, overload
 
 from ._async.functions_client import AsyncFunctionsClient

--- a/supabase_functions/_async/__init__.py
+++ b/supabase_functions/_async/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import annotations

--- a/supabase_functions/_sync/__init__.py
+++ b/supabase_functions/_sync/__init__.py
@@ -1,1 +1,0 @@
-from __future__ import annotations

--- a/supabase_functions/errors.py
+++ b/supabase_functions/errors.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import TypedDict
 
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Cleanout future imports `from __future__ import annotations` no longer needed for Python >= `3.9.0`.
