### PR TITLE
fix: Types to use Option[T]

### DIFF
--- a/supabase_functions/__init__.py
+++ b/supabase_functions/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, Union, overload
+from typing import Literal, Union, overload, Optional
 
 from ._async.functions_client import AsyncFunctionsClient
 from ._sync.functions_client import SyncFunctionsClient

--- a/supabase_functions/__init__.py
+++ b/supabase_functions/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Literal, Union, overload, Optional
+from typing import Literal, Optional, Union, overload
 
 from ._async.functions_client import AsyncFunctionsClient
 from ._sync.functions_client import SyncFunctionsClient

--- a/supabase_functions/_async/functions_client.py
+++ b/supabase_functions/_async/functions_client.py
@@ -35,7 +35,7 @@ class AsyncFunctionsClient:
         self,
         method: Literal["GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"],
         url: str,
-        headers: Union[Dict[str, str], None] = None,
+        headers: Optional[Dict[str, str]] = None,
         json: Optional[Dict[Any, Any]] = None,
     ) -> Response:
         response = await self._client.request(method, url, json=json, headers=headers)

--- a/supabase_functions/_sync/functions_client.py
+++ b/supabase_functions/_sync/functions_client.py
@@ -35,7 +35,7 @@ class SyncFunctionsClient:
         self,
         method: Literal["GET", "OPTIONS", "HEAD", "POST", "PUT", "PATCH", "DELETE"],
         url: str,
-        headers: Union[Dict[str, str], None] = None,
+        headers: Optional[Dict[str, str]] = None,
         json: Optional[Dict[Any, Any]] = None,
     ) -> Response:
         response = self._client.request(method, url, json=json, headers=headers)


### PR DESCRIPTION
## What kind of change does this PR introduce?

- Fix types to use `Option[T]` instead of Unions of Nones.
