### PR TITLE
fix: custom error status code from edge function returned correctly

### DIFF
--- a/supabase_functions/_async/functions_client.py
+++ b/supabase_functions/_async/functions_client.py
@@ -54,9 +54,14 @@ class AsyncFunctionsClient:
         try:
             response.raise_for_status()
         except HTTPError as exc:
+            status_code = None
+            if hasattr(response, "status_code"):
+                status_code = response.status_code
+
             raise FunctionsHttpError(
                 response.json().get("error")
-                or f"An error occurred while requesting your edge function at {exc.request.url!r}."
+                or f"An error occurred while requesting your edge function at {exc.request.url!r}.",
+                status_code,
             ) from exc
 
         return response

--- a/supabase_functions/_sync/functions_client.py
+++ b/supabase_functions/_sync/functions_client.py
@@ -54,9 +54,14 @@ class SyncFunctionsClient:
         try:
             response.raise_for_status()
         except HTTPError as exc:
+            status_code = None
+            if hasattr(response, "status_code"):
+                status_code = response.status_code
+
             raise FunctionsHttpError(
                 response.json().get("error")
-                or f"An error occurred while requesting your edge function at {exc.request.url!r}."
+                or f"An error occurred while requesting your edge function at {exc.request.url!r}.",
+                status_code,
             ) from exc
 
         return response

--- a/supabase_functions/errors.py
+++ b/supabase_functions/errors.py
@@ -25,20 +25,20 @@ class FunctionsError(Exception):
 
 
 class FunctionsHttpError(FunctionsError):
-    def __init__(self, message: str) -> None:
+    def __init__(self, message: str, code: int | None = None) -> None:
         super().__init__(
             message,
             "FunctionsHttpError",
-            400,
+            400 if code is None else code,
         )
 
 
 class FunctionsRelayError(FunctionsError):
     """Base exception for relay errors."""
 
-    def __init__(self, message: str) -> None:
+    def __init__(self, message: str, code: int | None = None) -> None:
         super().__init__(
             message,
             "FunctionsRelayError",
-            400,
+            400 if code is None else code,
         )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Custom error status code from edge function not being returned to the python library

## What is the new behavior?

Custom error status code from edge function is returned to the python library

## Additional context

Fix https://github.com/supabase/functions-py/issues/192
