### PR TITLE
fix: wrong default comment for responseType

### DIFF
--- a/supabase_functions/_async/functions_client.py
+++ b/supabase_functions/_async/functions_client.py
@@ -91,7 +91,7 @@ class AsyncFunctionsClient:
         invoke_options : object with the following properties
             `headers`: object representing the headers to send with the request
             `body`: the body of the request
-            `responseType`: how the response should be parsed. The default is `json`
+            `responseType`: how the response should be parsed. The default is `text/plain`
         """
         if not is_valid_str_arg(function_name):
             raise ValueError("function_name must a valid string value.")


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Comment shows that `json` is default behaviour while internal implementation uses `text/plain`  

## What is the new behavior?

Comment reflect real behaviour


