### PR TITLE
Remove bool cast of verify arg in `SyncFunctionsClient`

### DIFF
--- a/supabase_functions/_sync/functions_client.py
+++ b/supabase_functions/_sync/functions_client.py
@@ -33,7 +33,7 @@ class SyncFunctionsClient:
         self._client = SyncClient(
             base_url=self.url,
             headers=self.headers,
-            verify=bool(verify),
+            verify=verify,
             timeout=int(abs(timeout)),
             proxy=proxy,
             follow_redirects=True,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allows passing `ssl.SSLContext` to underlying `httpx.Client`

## What is the current behavior?

Closes #202

## What is the new behavior?

Allows passing `ssl.SSLContext` to underlying `httpx.Client`
