### PR TITLE
feat: allow injection of httpx client

### DIFF
--- a/supabase_functions/_async/functions_client.py
+++ b/supabase_functions/_async/functions_client.py
@@ -22,6 +22,7 @@ class AsyncFunctionsClient:
         timeout: int,
         verify: bool = True,
         proxy: Optional[str] = None,
+        http_client: Optional[AsyncClient] = None,
     ):
         if not is_http_url(url):
             raise ValueError("url must be a valid HTTP URL string")
@@ -30,15 +31,21 @@ class AsyncFunctionsClient:
             "User-Agent": f"supabase-py/functions-py v{__version__}",
             **headers,
         }
-        self._client = AsyncClient(
-            base_url=self.url,
-            headers=self.headers,
-            verify=bool(verify),
-            timeout=int(abs(timeout)),
-            proxy=proxy,
-            follow_redirects=True,
-            http2=True,
-        )
+
+        if http_client is not None:
+            http_client.base_url = self.url
+            http_client.headers.update({**self.headers})
+            self._client = http_client
+        else:
+            self._client = AsyncClient(
+                base_url=self.url,
+                headers=self.headers,
+                verify=bool(verify),
+                timeout=int(abs(timeout)),
+                proxy=proxy,
+                follow_redirects=True,
+                http2=True,
+            )
 
     async def _request(
         self,

--- a/supabase_functions/_sync/functions_client.py
+++ b/supabase_functions/_sync/functions_client.py
@@ -22,6 +22,7 @@ class SyncFunctionsClient:
         timeout: int,
         verify: bool = True,
         proxy: Optional[str] = None,
+        http_client: Optional[SyncClient] = None,
     ):
         if not is_http_url(url):
             raise ValueError("url must be a valid HTTP URL string")
@@ -30,15 +31,21 @@ class SyncFunctionsClient:
             "User-Agent": f"supabase-py/functions-py v{__version__}",
             **headers,
         }
-        self._client = SyncClient(
-            base_url=self.url,
-            headers=self.headers,
-            verify=bool(verify),
-            timeout=int(abs(timeout)),
-            proxy=proxy,
-            follow_redirects=True,
-            http2=True,
-        )
+
+        if http_client is not None:
+            http_client.base_url = self.url
+            http_client.headers.update({**self.headers})
+            self._client = http_client
+        else:
+            self._client = SyncClient(
+                base_url=self.url,
+                headers=self.headers,
+                verify=bool(verify),
+                timeout=int(abs(timeout)),
+                proxy=proxy,
+                follow_redirects=True,
+                http2=True,
+            )
 
     def _request(
         self,

--- a/tests/_async/test_function_client.py
+++ b/tests/_async/test_function_client.py
@@ -6,7 +6,7 @@ from httpx import HTTPError, Response, Timeout
 # Import the class to test
 from supabase_functions import AsyncFunctionsClient
 from supabase_functions.errors import FunctionsHttpError, FunctionsRelayError
-from supabase_functions.utils import FunctionRegion
+from supabase_functions.utils import AsyncClient, FunctionRegion
 from supabase_functions.version import __version__
 
 
@@ -197,3 +197,26 @@ async def test_invoke_with_json_body(client: AsyncFunctionsClient):
 
         _, kwargs = mock_request.call_args
         assert kwargs["headers"]["Content-Type"] == "application/json"
+
+
+async def test_init_with_httpx_client():
+    # Create a custom httpx client with specific options
+    custom_client = AsyncClient(
+        timeout=Timeout(30), follow_redirects=True, max_redirects=5
+    )
+
+    # Initialize the functions client with the custom httpx client
+    client = AsyncFunctionsClient(
+        url="https://example.com",
+        headers={"Authorization": "Bearer token"},
+        timeout=30,
+        http_client=custom_client,
+    )
+
+    # Verify the custom client options are preserved
+    assert client._client.timeout == Timeout(30)
+    assert client._client.follow_redirects is True
+    assert client._client.max_redirects == 5
+
+    # Verify the client is properly configured with our custom client
+    assert client._client is custom_client

--- a/tests/_sync/test_function_client.py
+++ b/tests/_sync/test_function_client.py
@@ -6,7 +6,7 @@ from httpx import HTTPError, Response, Timeout
 # Import the class to test
 from supabase_functions import SyncFunctionsClient
 from supabase_functions.errors import FunctionsHttpError, FunctionsRelayError
-from supabase_functions.utils import FunctionRegion
+from supabase_functions.utils import FunctionRegion, SyncClient
 from supabase_functions.version import __version__
 
 
@@ -181,3 +181,26 @@ def test_invoke_with_json_body(client: SyncFunctionsClient):
 
         _, kwargs = mock_request.call_args
         assert kwargs["headers"]["Content-Type"] == "application/json"
+
+
+def test_init_with_httpx_client():
+    # Create a custom httpx client with specific options
+    custom_client = SyncClient(
+        timeout=Timeout(30), follow_redirects=True, max_redirects=5
+    )
+
+    # Initialize the functions client with the custom httpx client
+    client = SyncFunctionsClient(
+        url="https://example.com",
+        headers={"Authorization": "Bearer token"},
+        timeout=30,
+        http_client=custom_client,
+    )
+
+    # Verify the custom client options are preserved
+    assert client._client.timeout == Timeout(30)
+    assert client._client.follow_redirects is True
+    assert client._client.max_redirects == 5
+
+    # Verify the client is properly configured with our custom client
+    assert client._client is custom_client


### PR DESCRIPTION
## What kind of change does this PR introduce?

Allow developers to supply their own httpx client

## What is the current behavior?

Httpx client isn't very configurable and has limited options available for the developer

## What is the new behavior?

Httpx client can now be configured by the developer and be supplied to the functions library

## Additional context

Add any other context or screenshots.
